### PR TITLE
[HOTFIX] Erro ao gerar arquivo do relatório

### DIFF
--- a/src/controllers/Report.controller.ts
+++ b/src/controllers/Report.controller.ts
@@ -42,7 +42,6 @@ export default {
                 return response.status(500).json({ error: "Erro ao gerar o relatório" });
             }
 
-            console.log(sendFile(response, filePath, result.numSerie));
             return sendFile(response, filePath, result.numSerie);
         }
         catch (error) {


### PR DESCRIPTION
## Qual o tipo do PR?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Otimização
- [ ] Documentação

## Descrição

Remove o `console.log()` que duplica a chamada da função `sendFile()` para gerar o arquivo do relatório do equipamento.

## Issues relacionadas

- closes #49

## Testes adicionados ou atualizados?

- [ ] Sim;
- [x] Não, porque ja existe testes para esse modulo;
- [ ] Preciso de ajuda para implementar os testes;